### PR TITLE
Fix requires versions

### DIFF
--- a/django_happymailer/settings.py
+++ b/django_happymailer/settings.py
@@ -35,7 +35,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'happymailer.apps.HappymailerConfig',
+    'happymailer',
     'dummy',
     'dummy2'
 ]

--- a/happymailer/__init__.py
+++ b/happymailer/__init__.py
@@ -14,6 +14,9 @@ from .utils import all_template_classes, all_layout_classes, get_layout, Templat
 from .backends.base import InvalidVariableException
 
 
+default_app_config = 'happymailer.apps.HappymailerConfig'
+
+
 __all__ = ('Template', 'Layout', 't')
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 diff-match-patch==20121119
 Django==1.9.7
 django-import-export==0.4.5
-fake-factory==0.5.7
+fake-factory==0.7.2
 html2text==2016.5.29
-python-dateutil==2.5.3
+python-dateutil==2.6.0
+requests==2.11.0
+requests-toolbelt==0.7.0
 six==1.10.0
 sqlparse==0.1.19
 tablib==0.11.2

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     packages=find_packages(exclude=['django_happymailer','dummy','dummy2']),
     install_requires=[
         'django >= 1.9',
-        'django-import-export == 0.4.5',
-        'fake-factory == 0.5.7',
+        'django-import-export >= 0.4.5',
+        'fake-factory >= 0.5.7',
         'html2text == 2016.5.29',
         'trafaret >= 0.7',
         'six',


### PR DESCRIPTION
Fixed version numbers to avoid dependency conflicts, because related projects may use higher version of some python packages.