### PR TITLE
Django 3.0

### DIFF
--- a/happymailer/templates/admin/happymailer/templatemodel/base.html
+++ b/happymailer/templates/admin/happymailer/templatemodel/base.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify %}
+{% load i18n static admin_modify %}
 {% load admin_urls %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}

--- a/happymailer/templates/admin/happymailer/templatemodel/change_form.html
+++ b/happymailer/templates/admin/happymailer/templatemodel/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls admin_static admin_modify %}
+{% load i18n admin_urls static admin_modify %}
 
 {% block content %}
 <div id="content-main">

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-happymailer',
-    version='0.2.1',
+    version='0.3.1',
     description='django email templates manager',
     author='Victor Kotcheruba',
     author_email='barbuzaster@gmail.com',
@@ -11,7 +11,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['django_happymailer','dummy','dummy2']),
     install_requires=[
-        'django >= 2.0',
+        'django >= 3.0',
         'django-import-export >= 0.4.5',
         'faker >= 0.8.6',
         'html2text >= 2016.5.29',


### PR DESCRIPTION
`admin_static` has been removed in Django 3.0. See here for more info: https://github.com/jazzband/django-constance/issues/366